### PR TITLE
Update to CBitcoinSecret::IsValid() to accept previously used SECRET_KEY...

### DIFF
--- a/src/base58.cpp
+++ b/src/base58.cpp
@@ -261,7 +261,7 @@ CKey CBitcoinSecret::GetKey() {
 
 bool CBitcoinSecret::IsValid() const {
     bool fExpectedFormat = vchData.size() == 32 || (vchData.size() == 33 && vchData[32] == 1);
-    bool fCorrectVersion = vchVersion == Params().Base58Prefix(CChainParams::SECRET_KEY);
+    bool fCorrectVersion = vchVersion == Params().Base58Prefix(CChainParams::SECRET_KEY) || vchVersion == Params().Base58Prefix(CChainParams::SECRET_KEY_OLD);
     return fExpectedFormat && fCorrectVersion;
 }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -73,7 +73,8 @@ public:
 
         base58Prefixes[PUBKEY_ADDRESS] = list_of(30);
         base58Prefixes[SCRIPT_ADDRESS] = list_of(5);
-        base58Prefixes[SECRET_KEY] =     list_of(128);
+        base58Prefixes[SECRET_KEY]     = list_of(128);
+        base58Prefixes[SECRET_KEY_OLD] = list_of(158);
         base58Prefixes[EXT_PUBLIC_KEY] = list_of(0x04)(0x88)(0xB2)(0x1E);
         base58Prefixes[EXT_SECRET_KEY] = list_of(0x04)(0x88)(0xAD)(0xE4);
         // Convert the pnSeeds array into usable address objects.

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -48,6 +48,7 @@ public:
         PUBKEY_ADDRESS,
         SCRIPT_ADDRESS,
         SECRET_KEY,
+	SECRET_KEY_OLD,
         EXT_PUBLIC_KEY,
         EXT_SECRET_KEY,
 


### PR DESCRIPTION
... prefix.

Fix for importing old keys that use that prefix.
