### PR TITLE
New work calculation at block 600000 (soft fork)

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -687,6 +687,7 @@ enum BlockStatus {
 
 const int64_t multiAlgoDiffChangeTarget = 145000; // block 145000 where multi-algo work weighting starts 145000
 const int64_t alwaysUpdateDiffChangeTarget = 400000; // block 400000 after which all difficulties are updated on every block
+const int64_t workComputationChangeTarget = 600000; // block 600000 new work computation algorithm
 
 /** The block chain is a tree shaped structure starting with the
  * genesis block at the root, with each block potentially having multiple
@@ -861,9 +862,32 @@ public:
 
     CBigNum GetBlockWorkAdjusted() const
     {
-        CBigNum bnRes;
-        bnRes = GetBlockWork() * GetAlgoWorkFactor();
-        return bnRes;
+        if (nHeight < workComputationChangeTarget)
+        {
+            CBigNum bnRes;
+            bnRes = GetBlockWork() * GetAlgoWorkFactor();
+            return bnRes;
+        }
+        else
+        {
+            CBigNum bnRes = 1;
+            CBlockHeader header = GetBlockHeader();
+            // multiply the difficulties of all algorithms
+            for (int i = 0; i < NUM_ALGOS; i++)
+            {
+                unsigned int nBits = GetNextWorkRequired(pprev, &header, i);
+                CBigNum bnTarget;
+                bnTarget.SetCompact(nBits);
+                if (bnTarget <= 0)
+                    return 0;
+                bnRes *= (CBigNum(1)<<256) / (bnTarget+1);
+            }
+            // Compute the geometric mean
+            bnRes = bnRes.nthRoot(NUM_ALGOS);
+            // Scale to roughly match the old work calculation
+            bnRes <<= 7;
+            return bnRes;
+        }
     }
     
     bool CheckIndex() const

--- a/src/test/bignum_tests.cpp
+++ b/src/test/bignum_tests.cpp
@@ -221,4 +221,44 @@ BOOST_AUTO_TEST_CASE(bignum_SetHex)
     BOOST_CHECK_EQUAL(num.GetHex(), hexStr);
 }
 
+void nthRootHelper(const CBigNum& k, int n)
+{
+    CBigNum r = k.nthRoot(n);
+    CBigNum lo = 1, hi = 1;
+    for (int i = 0; i < n; i++)
+    {
+        lo *= r;
+        hi *= r+1;
+    }
+    BOOST_CHECK(lo <= k && k < hi);
+}
+
+BOOST_AUTO_TEST_CASE(bignum_nthRoot)
+{
+    // small sanity cases
+    for (int i = 0; i < 200; i++)
+    {
+        for (int j = 2; j <= 10; j++)
+        {
+            nthRootHelper(i, j);
+        }
+    }
+    for (int i = 200; i < 5000; i++)
+    {
+        nthRootHelper(i, (rand() % 9) + 2);
+    }
+    // large random cases
+    for (int i = 0; i < 1000; i++)
+    {
+        int nBitLength = (rand() % 200) + 50;
+        uint256 u;
+        for (unsigned char* p = u.begin(); p != u.end(); p++)
+            *p = rand() & 0xff;
+        u &= (uint256(1) << nBitLength) - 1;
+        CBigNum k;
+        k.setuint256(u);
+        nthRootHelper(k, (rand() % 9) + 2);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
First off, this will fix the safe mode warnings once and for all.  But it does so much more than that.  Currently, an attacker can 51% attack the network with roughly 60% of SHA256D and nothing else.  After this change, an attacker with 90% of the SHA256D hashrate and 33% of each of the other 4 algorithms would have insufficient hashpower to mount a 51% attack.

The new formula was chosen as a function of the difficulties and based on these criteria:
1. It should be a symmetric funtion
2. It should be order 1 homogenous
3. It should be homogenous with respect to each variable

Or in plain English:
1. There should be nothing algorithm-specific (such as per-algorithm weights) nor should it depend on which algorithm actually solved the block.
2. If all difficulties double, the block work should double
3. If one difficulty doubles, the block work should change by some constant factor

There is only one function (save multiplication by a constant factor) satisfying all 3 conditions: the geometric mean.  As an added bonus, because of how the difficulty algorithm works the geometric mean can change by at most 3% from block to block (which addresses the safe-mode warning issue).

In order to 51% attack the network, the product of the attacker's hashrates must exceed the product of the network's hashrates.  In particular, the attacker must have some hashrate in all 5 algorithms.
