### PR TITLE
Soft-fork: reserve algo ids for upcoming hard-fork

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -170,6 +170,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_NVERSIONBIPS].nStartTime = 1489997089; // March 24th, 2017 1490355345
         consensus.vDeployments[Consensus::DEPLOYMENT_NVERSIONBIPS].nTimeout = 1521891345;    // March 24th, 2018
 
+        // Reservation of version bits for future algos
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].bit = 12;
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nStartTime = 1542672000; // 20 Nov, 2018
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nTimeout = 1574208000;   // 20 Nov, 2019
+
         // Deployment of Equihash algo softfork
         //consensus.vDeployments[Consensus::DEPLOYMENT_EQUIHASH].bit = 3;
         //consensus.vDeployments[Consensus::DEPLOYMENT_EQUIHASH].nStartTime = 1489997089; // July, 2017 
@@ -363,6 +368,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_NVERSIONBIPS].bit = 14; //Add VERSIONBITS_NUM_BITS_TO_SKIP (12)
         consensus.vDeployments[Consensus::DEPLOYMENT_NVERSIONBIPS].nStartTime = 1489997089; // March 24th, 2017 149
 
+        // Reservation of version bits for future algos
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].bit = 12;
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");
 
@@ -485,6 +495,9 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 1;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].bit = 2;
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_RESERVEALGO].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
         // The best chain should have at least this much work.
         consensus.nMinimumChainWork = uint256S("0x00");

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -19,6 +19,7 @@ enum DeploymentPos
     DEPLOYMENT_CSV, // Deployment of BIP68, BIP112, and BIP113.
     DEPLOYMENT_SEGWIT, // Deployment of BIP141, BIP143, and BIP147.
     DEPLOYMENT_NVERSIONBIPS, // Deployment of BIP34, BIP65, and BIP66.
+    DEPLOYMENT_RESERVEALGO,  // Reservation of version bits for future algos
     //DEPLOYMENT_EQUIHASH, // Equihash algo swap
     //DEPLOYMENT_ETHASH, // Ethash algo swap
     // NOTE: Also add new deployments to VersionBitsDeploymentInfo in versionbits.cpp

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -28,7 +28,7 @@ enum {
     BLOCK_VERSION_DEFAULT        = 2, 
 
     // algo
-    BLOCK_VERSION_ALGO           = (7 << 9),
+    BLOCK_VERSION_ALGO           = (15 << 8),
     BLOCK_VERSION_SCRYPT         = (0 << 9),
     BLOCK_VERSION_SHA256D        = (1 << 9),
     BLOCK_VERSION_GROESTL        = (2 << 9),

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3343,6 +3343,14 @@ static bool ContextualCheckBlockHeader(const CBlockHeader& block, CValidationSta
     if (block.nBits != GetNextWorkRequired(pindexPrev, &block, consensusParams, block.GetAlgo()))
         return state.DoS(100, false, REJECT_INVALID, "bad-diffbits", false, "incorrect proof of work");
 
+    // Check for non-standard SCRYPT version.
+    if (VersionBitsState(pindexPrev, consensusParams, Consensus::DEPLOYMENT_RESERVEALGO, versionbitscache) == ThresholdState::ACTIVE &&
+        block.GetAlgo() == ALGO_SCRYPT &&
+        (block.nVersion & BLOCK_VERSION_ALGO) != BLOCK_VERSION_SCRYPT)
+    {
+        return state.Invalid(false, REJECT_INVALID, "invalid-algo", "invalid algo id");
+    }
+
     // Check against checkpoints
     if (fCheckpointsEnabled) {
         // Don't accept any forks from the main chain prior to last checkpoint.

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -21,7 +21,11 @@ const struct VBDeploymentInfo VersionBitsDeploymentInfo[Consensus::MAX_VERSION_B
     {
         /*.name =*/ "nversionbips",
         /*.gbt_force =*/ true,
-    }
+    },
+    {
+        /*.name =*/ "reservealgo",
+        /*.gbt_force =*/ true,
+    },
     //{
        // /*.name =*/ "equihash",
         ///*.gbt_force =*/ true,


### PR DESCRIPTION
No block has ever been mined with a non-standard SCRYPT version, but the code currently allows it.  This is problematic for algo-swap hard-forks, so to make the upcoming hard-fork easier we do a soft-fork now that forbids non-standard SCRYPT versions.  We'll need miners to upgrade.  Non-miners are not required to upgrade, however those that do not upgrade should not accept transactions with an extremely low number of confirmations (not that that was ever a good idea anyway).  This is because someone making a double-spend attempt gets a free 1-block lead versus honest miners against non-upgraded wallets.