### PR TITLE
Update license year 2019

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,7 @@
 The MIT License (MIT)
 
-Copyright (c) 2009-2018 The DigiByte Core developers
-Copyright (c) 2009-2018 DigiByte Developers
+Copyright (c) 2009-2019 The DigiByte Core developers
+Copyright (c) 2009-2019 DigiByte Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -74,11 +74,11 @@ Build requirements:
 
 BerkeleyDB is required for the wallet.
 
-**For Ubuntu only:** db4.8 packages are available [here](https://launchpad.net/~digibyte/+archive/digibyte).
+**For Ubuntu only:** db4.8 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
 You can add the repository and install using the following commands:
 
     sudo apt-get install software-properties-common
-    sudo add-apt-repository ppa:digibyte/digibyte
+    sudo add-apt-repository ppa:bitcoin/bitcoin
     sudo apt-get update
     sudo apt-get install libdb4.8-dev libdb4.8++-dev
 


### PR DESCRIPTION
### Fix license of use, 
update 2019; 
Format ISO 8869-1;
----------------------------------------------------------------------------------------------------------------------
in Memoriam Guto Schiavon 
![guto-schiavon_bitcoin](https://user-images.githubusercontent.com/7637553/50562143-a7506f80-0cf8-11e9-9e58-bed4565c4715.jpg)
R.I.P pioneer and friend. 

#ripGUTO