### PR TITLE
Addressing weak points of the first testnet run of the odo fork

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -298,7 +298,6 @@ public:
     uint256 GetBlockPoWHash() const
     {
         CBlockHeader block = GetBlockHeader();
-        int algo = block.GetAlgo();
         return GetPoWAlgoHash(block);
     }
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -83,6 +83,7 @@ public:
         consensus.BIP66Height = 4394880; // 
 
         consensus.powLimit = ArithToUint256(~arith_uint256(0) >> 20);
+        consensus.initialTarget[ALGO_ODO] = ArithToUint256(~arith_uint256(0) >> 40); // 256 difficulty
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 60 / 4;
 
@@ -289,6 +290,7 @@ public:
     CTestNetParams() {
         strNetworkID = "test";
         consensus.powLimit = ArithToUint256(~arith_uint256(0) >> 20);
+        consensus.initialTarget[ALGO_ODO] = ArithToUint256(~arith_uint256(0) >> 36); // 16 difficulty
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 60 / 4;
 

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -349,10 +349,10 @@ public:
 
 
         // DigiByte Hard Fork Block Heights
-        consensus.multiAlgoDiffChangeTarget = 145; // Block 145,000 MultiAlgo Hard Fork
+        consensus.multiAlgoDiffChangeTarget = 100; // Block 145,000 MultiAlgo Hard Fork
         consensus.alwaysUpdateDiffChangeTarget = 400; // Block 400,000 MultiShield Hard Fork
         consensus.workComputationChangeTarget = 1430; // Block 1,430,000 DigiSpeed Hard Fork
-        consensus.algoSwapChangeTarget = 2000; // Block 9,000,000 Odo PoW Hard Fork
+        consensus.algoSwapChangeTarget = 20000; // Block 9,000,000 Odo PoW Hard Fork
 
         consensus.fPowAllowMinDifficultyBlocks = true;
         consensus.fPowNoRetargeting = false;
@@ -366,17 +366,17 @@ public:
 
         // Deployment of BIP68, BIP112, and BIP113.
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 12; //Add VERSIONBITS_NUM_BITS_TO_SKIP (12)
-        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1489997089; // March 24th, 2017 1490355345
+        consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
         // Deployment of SegWit (BIP141, BIP143, and BIP147)
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].bit = 13; //Add VERSIONBITS_NUM_BITS_TO_SKIP (12)
-        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = 1490355345; // March 24th, 2017 1490355345
+        consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_SEGWIT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
         // Deployment of BIP65, BIP66, and BIP34.
         consensus.vDeployments[Consensus::DEPLOYMENT_NVERSIONBIPS].bit = 14; //Add VERSIONBITS_NUM_BITS_TO_SKIP (12)
-        consensus.vDeployments[Consensus::DEPLOYMENT_NVERSIONBIPS].nStartTime = 1489997089; // March 24th, 2017 149
+        consensus.vDeployments[Consensus::DEPLOYMENT_NVERSIONBIPS].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
         consensus.vDeployments[Consensus::DEPLOYMENT_NVERSIONBIPS].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
 
         // Reservation of version bits for future algos

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -35,7 +35,7 @@ std::unique_ptr<CBaseChainParams> CreateBaseChainParams(const std::string& chain
     if (chain == CBaseChainParams::MAIN)
         return MakeUnique<CBaseChainParams>("", 14022);
     else if (chain == CBaseChainParams::TESTNET)
-        return MakeUnique<CBaseChainParams>("testnet3", 18332);
+        return MakeUnique<CBaseChainParams>("testnet4", 14023);
     else if (chain == CBaseChainParams::REGTEST)
         return MakeUnique<CBaseChainParams>("regtest", 18443);
     else

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -75,6 +75,7 @@ struct Params {
     BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
     /** Proof of work parameters */
     uint256 powLimit;
+    std::map<int, uint256> initialTarget;
     bool fPowAllowMinDifficultyBlocks;
     bool fPowNoRetargeting;
     bool fRbfEnabled;

--- a/src/crypto/odocrypt.cpp
+++ b/src/crypto/odocrypt.cpp
@@ -46,7 +46,7 @@ struct OdoRandom
     {
         for (size_t i = 0; i < sz; i++)
             arr[i] = i;
-        for (int i = 1; i < sz; i++)
+        for (size_t i = 1; i < sz; i++)
             std::swap(arr[i], arr[Next(i+1)]);
     }
 

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -19,6 +19,14 @@ inline unsigned int PowLimit(const Consensus::Params& params)
     return UintToArith256(params.powLimit).GetCompact();
 }
 
+inline unsigned int InitialDifficulty(const Consensus::Params& params, int algo)
+{
+    const auto& it = params.initialTarget.find(algo);
+    if (it == params.initialTarget.end())
+        return PowLimit(params);
+    return UintToArith256(it->second).GetCompact();
+}
+
 unsigned int GetNextWorkRequiredV1(const CBlockIndex* pindexLast, const Consensus::Params& params, int algo)
 {
 	int nHeight = pindexLast->nHeight + 1;
@@ -106,7 +114,7 @@ unsigned int GetNextWorkRequiredV2(const CBlockIndex* pindexLast, const Consensu
 	if (pindexFirst == nullptr)
 	{
 		LogPrintf("Use default POW Limit\n");
-		return PowLimit(params);
+		return InitialDifficulty(params, algo);
 	}
 
 	// Limit adjustment step
@@ -142,7 +150,7 @@ unsigned int GetNextWorkRequiredV3(const CBlockIndex* pindexLast, const Consensu
 	}
 	const CBlockIndex* pindexPrevAlgo = GetLastBlockIndexForAlgo(pindexLast, params, algo);
 	if (pindexPrevAlgo == nullptr || pindexFirst == nullptr)
-		return PowLimit(params); // not enough blocks available
+		return InitialDifficulty(params, algo); // not enough blocks available
 
 	// Limit adjustment step
 	// Use medians to prevent time-warp attacks
@@ -197,7 +205,7 @@ unsigned int GetNextWorkRequiredV4(const CBlockIndex* pindexLast, const Consensu
 	const CBlockIndex* pindexPrevAlgo = GetLastBlockIndexForAlgo(pindexLast, params, algo);
 	if (pindexPrevAlgo == nullptr || pindexFirst == nullptr)
 	{
-		return PowLimit(params);
+		return InitialDifficulty(params, algo);
 	}
 
 	// Limit adjustment step
@@ -248,7 +256,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
 {
     // Genesis block
     if (pindexLast == nullptr)
-        return PowLimit(params);
+        return InitialDifficulty(params, algo);
 
     if (params.fPowAllowMinDifficultyBlocks)
     {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1101,7 +1101,6 @@ bool ReadBlockFromDisk(CBlock& block, const CDiskBlockPos& pos, const Consensus:
     }
 
     // Check the header
-    int nAlgo = block.GetAlgo();
     if (!CheckProofOfWork(GetPoWAlgoHash(block), block.nBits, consensusParams))
         return error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
 

--- a/src/version.h
+++ b/src/version.h
@@ -10,7 +10,7 @@
  * network protocol versioning
  */
 
-static const int PROTOCOL_VERSION = 70016;
+static const int PROTOCOL_VERSION = 70017;
 
 //! initial proto version, to be increased after version/verack negotiation
 static const int INIT_PROTO_VERSION = 209;
@@ -42,5 +42,8 @@ static const int SHORT_IDS_BLOCKS_VERSION = 70014;
 
 //! not banning for invalid compact blocks starts with this version
 static const int INVALID_CB_NO_BAN_VERSION = 70015;
+
+//! first odo version
+static const int ODO_FORK_VERSION = 70017;
 
 #endif // DIGIBYTE_VERSION_H

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -3925,7 +3925,7 @@ UniValue generate(const JSONRPCRequest& request)
     }
     int algo = miningAlgo;
     if (!request.params[2].isNull()) {
-        algo = GetAlgoByName(request.params[3].get_str(), algo);
+        algo = GetAlgoByName(request.params[2].get_str(), algo);
     }
 
     std::shared_ptr<CReserveScript> coinbase_script;


### PR DESCRIPTION
On the first testnet run of the odo fork, there were 2 notable areas to improve.  First, starting at the minimum possible difficulty leads to a large number of odo blocks being mined in an extremely short period.  Here I increase the starting difficulty by a factor of 2^16 on testnet and 2^20 on mainnet.  Second, traditionally there's another update immediately after a hard-fork that automatically disconnects outdated peers.  Here I have old peers automatically disconnect, but only after the fork happens.