### PR TITLE
Dandelion: verify existence of embargoed transactions in stempool

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1115,12 +1115,15 @@ static void CheckDandelionEmbargoes(CConnman* connman)
             LogPrint(BCLog::DANDELION, "dandeliontx %s embargo expired\n", iter->first.ToString());
             CValidationState state;
             CTransactionRef ptx = stempool.get(iter->first);
-            bool fMissingInputs = false;
-            std::list<CTransactionRef> lRemovedTxn;
-            AcceptToMemoryPool(mempool, state, ptx, &fMissingInputs, &lRemovedTxn, false /* bypass_limits */, 0 /* nAbsurdFee */);
-            LogPrint(BCLog::MEMPOOL, "AcceptToMemoryPool: accepted %s (poolsz %u txn, %u kB)\n",
-                     iter->first.ToString(), mempool.size(), mempool.DynamicMemoryUsage() / 1000);
-            RelayTransaction(*ptx, connman);
+            if (ptx)
+            {
+                bool fMissingInputs = false;
+                std::list<CTransactionRef> lRemovedTxn;
+                AcceptToMemoryPool(mempool, state, ptx, &fMissingInputs, &lRemovedTxn, false /* bypass_limits */, 0 /* nAbsurdFee */);
+                LogPrint(BCLog::MEMPOOL, "AcceptToMemoryPool: accepted %s (poolsz %u txn, %u kB)\n",
+                         iter->first.ToString(), mempool.size(), mempool.DynamicMemoryUsage() / 1000);
+                RelayTransaction(*ptx, connman);
+            }
             iter = connman->mDandelionEmbargo.erase(iter);
         } else {
             iter++;


### PR DESCRIPTION
Other places in the code remove transactions from the stempool without removing the corresponding embargoes.  When an embargo expires for a transaction not in the stempool it can be ignored.