### PR TITLE
Adding mention of Odocrypt hardfork details

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ MultiShield Hardfork: Block 400k, Dec. 10th 2014
 
 DigiSpeed Hardfork: Block 1,430,000 Dec. 4th 2015
 
+Odocrypt Hardfork: Block 9,112,320 July 22nd 2019
+
 DigiByte vs Bitcoin
 -------------------
 


### PR DESCRIPTION
README has not been updated since the Odocrypt upgrade, added block details