### PR TITLE
test: correct txindex_tests

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -504,6 +504,7 @@ public:
         consensus.alwaysUpdateDiffChangeTarget = 400; // Block 400,000 MultiShield Hard Fork
         consensus.workComputationChangeTarget = 1430; // Block 1,430,000 DigiSpeed Hard Fork
         consensus.algoSwapChangeTarget = 2000; // Block 9,000,000 Odo PoW Hard Fork
+        consensus.nMinerConfirmationWindow = 3600; // 1 hour in RegTest
 
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].bit = 28;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nStartTime = 0;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -46,6 +46,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
+#include <boost/bind.hpp>
 
 #if defined(NDEBUG)
 # error "DigiByte cannot be compiled without assertions."

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <future>
 
+#include <boost/bind.hpp>
 #include <boost/signals2/signal.hpp>
 
 struct MainSignalsInstance {


### PR DESCRIPTION
# DigiByte specific txindex_tests

### What is the intention of this PR?
This PR fixes the `txindex_tests` by respecting DigiBytes specific Chainparameters and MultiAlgo implementation.

### Description of the changes
https://github.com/digibyte/digibyte/commit/9c9d1c151df6858f9e4392b318d52d8be6d389ad updated the `txindex_tests` unit test so that all checks are properly resolving.

### How to verify?
1) Change to the directory src/test
2) Compile the test suite
3) Run it using
```bash
./test_digibyte --run_test=txindex_tests
```

### Expected outcome
```
$ ./test_digibyte --run_test=txindex_tests 
Running 1 test case...

*** No errors detected
```